### PR TITLE
Expose artist, song, and genre info via KB API

### DIFF
--- a/command_evaluation/eval_engine.py
+++ b/command_evaluation/eval_engine.py
@@ -170,7 +170,7 @@ class EvalEngine:
                                 ):
         similar_entities = []
         for e in subjects:
-            similar_entities += self.kb_api.get_similar_entities(e)
+            similar_entities += self.kb_api.get_related_entities(e)
 
         if not similar_entities:
             self.player.respond("I'm sorry, I couldn't find that for you.")

--- a/knowledge_base/api.py
+++ b/knowledge_base/api.py
@@ -128,7 +128,7 @@ class KnowledgeBaseAPI:
             print("ERROR: Could not retrieve music entities: {}".format(e))
 
     def _get_matching_node_ids(self, node_name):
-        """Retrieves IDs of all node matching the given name.
+        """Retrieves IDs of all nodes matching the given name.
 
         Params:
             node_name (string): name of entity node. E.g. "Justin Bieber".
@@ -178,18 +178,18 @@ class KnowledgeBaseAPI:
         Returns:
             (bool): False if error occurred, True otherwise.
         """
-        candidate_source_ids = self._get_matching_node_ids(source_node_name)
-        candidate_dest_ids = self._get_matching_node_ids(dest_node_name)
-        if len(candidate_source_ids) != 1 or len(candidate_dest_ids) != 1:
+        matching_src_nodes = self._get_matching_node_ids(source_node_name)
+        matching_dst_nodes = self._get_matching_node_ids(dest_node_name)
+        if len(matching_src_nodes) != 1 or len(matching_dst_nodes) != 1:
             print("ERROR: Could not find unique match for entities '{}', '{}'. Found {}, {} matches respectively" .format(
                 source_node_name,
                 dest_node_name,
-                len(candidate_source_ids),
-                len(candidate_dest_ids)),
+                len(matching_src_nodes),
+                len(matching_dst_nodes)),
             )
             return False
 
-        source_node_id, dest_node_id = candidate_source_ids[0], candidate_dest_ids[0]
+        source_node_id, dest_node_id = matching_src_nodes[0], matching_dst_nodes[0]
 
         try:
             with closing(self.connection) as conn:

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -22,13 +22,18 @@ CREATE TABLE edges(
     PRIMARY KEY (source, dest, rel)
 );
 
--- TODO: Create trigger functions to add to nodes + edges table
 CREATE TABLE artists(
-    node_id int PRIMARY KEY REFERENCES nodes(id) NOT NULL
+    node_id                 int PRIMARY KEY REFERENCES nodes(id) NOT NULL,
+    num_spotify_followers   int
 );
 
--- TODO: Create trigger functions to add to nodes + edges table
 CREATE TABLE songs(
     main_artist_id  int REFERENCES artists(node_id) NOT NULL,
+    popularity      int CHECK ((popularity >= 0 AND popularity <= 100) OR popularity = NULL),
+    duration_ms     int,
     node_id         int REFERENCES nodes(id) NOT NULL
+);
+
+CREATE TABLE genres(
+    node_id int REFERENCES nodes(id) NOT NULL
 );

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -13,18 +13,11 @@ CREATE TABLE nodes(
     id INTEGER PRIMARY KEY
 );
 
-CREATE TABLE relations(
-    -- e.g. "similar to"
-    type        varchar(40) NOT NULL PRIMARY KEY,
-    -- e.g. false for "similar to" relations, but true for
-    is_directed boolean NOT NULL
-);
-
 -- TODO: add constraints about node type (probably in a trigger function)
 CREATE TABLE edges(
     source  int NOT NULL REFERENCES nodes(id),
     dest    int NOT NULL REFERENCES nodes(id),
-    rel     varchar(40) NOT NULL REFERENCES relations(type),
+    rel     varchar(40) NOT NULL,
     score   real NOT NULL CHECK (score >= 0 AND score <= 100),
     PRIMARY KEY (source, dest, rel)
 );
@@ -39,5 +32,3 @@ CREATE TABLE songs(
     main_artist_id  int REFERENCES artists(node_id) NOT NULL,
     node_id         int REFERENCES nodes(id) NOT NULL
 );
-
-INSERT INTO relations (type, is_directed) VALUES ("similar to", false);

--- a/scripts/spotify_client.py
+++ b/scripts/spotify_client.py
@@ -104,12 +104,12 @@ class SpotifyClient():
             related_artists[hit["name"]] = dict(
                 ID=hit["id"],
                 genres=hit["genres"],
-                numFollowers=int(hit["followers"]["total"]),
+                num_followers=int(hit["followers"]["total"]),
             )
         return related_artists
 
-    def get_artist_id(self, artist):
-        """Retrieves the Spotify ID of specified artist.
+    def get_artist_data(self, artist):
+        """Retrieves summary data regarding specified artist.
 
         Naively resolves artist ambiguity by taking first result.
 
@@ -117,7 +117,12 @@ class SpotifyClient():
             artist (string): e.g. "Justin Bieber"
 
         Returns:
-            (string): Spotify's artist ID; None if search failed or rendered no results.
+            (dict): keys: id, num_followers, genres. None if search failed or rendered no results.
+                e.g. {
+                    id=1uNFoZAHBGtllmzznpCI3s,
+                    num_followers=25683438,
+                    genres=["canadian pop", "dance pop", "pop", "post-teen pop"]
+                }
         """
         params = dict(q=artist, type="artist")
         headers = self.set_token_in_auth_header(dict())
@@ -143,7 +148,11 @@ class SpotifyClient():
             print("Could not find info for artist '{}'".format(artist))
             return None
 
-        return body["artists"]["items"][0]["id"]
+        return dict(
+            id=body["artists"]["items"][0]["id"],
+            num_followers=body["artists"]["items"][0]["followers"]["total"],
+            genres=body["artists"]["items"][0]["genres"],
+        )
 
     def get_top_songs(self, artist_ID, country_iso_code):
         """Retrieves metadata of the specified artist's top songs on Spotify.

--- a/scripts/test_data.sql
+++ b/scripts/test_data.sql
@@ -12,8 +12,10 @@ INSERT INTO nodes VALUES ("Despacito", "song", 10);
 INSERT INTO nodes VALUES ("Rock Your Body", "song", 11);
 INSERT INTO nodes VALUES ("Beautiful Day", "song", 12);
 INSERT INTO nodes VALUES ("In My Blood", "song", 13);
+INSERT INTO nodes VALUES ("Sorry", "song", 14);
 
 INSERT INTO songs VALUES (1, 10);
+INSERT INTO songs VALUES (1, 14);
 INSERT INTO songs VALUES (2, 11);
 INSERT INTO songs VALUES (3, 12);
 INSERT INTO songs VALUES (4, 13);

--- a/scripts/test_data.sql
+++ b/scripts/test_data.sql
@@ -1,35 +1,41 @@
-INSERT INTO nodes VALUES ("Justin Bieber", "artist", 1);
-INSERT INTO nodes VALUES ("Justin Timberlake", "artist", 2);
-INSERT INTO nodes VALUES ("U2", "artist", 3);
-INSERT INTO nodes VALUES ("Shawn Mendes", "artist", 4);
+INSERT INTO nodes (name, type, id) VALUES ("Justin Bieber", "artist", 1);
+INSERT INTO nodes (name, type, id) VALUES ("Justin Timberlake", "artist", 2);
+INSERT INTO nodes (name, type, id) VALUES ("U2", "artist", 3);
+INSERT INTO nodes (name, type, id) VALUES ("Shawn Mendes", "artist", 4);
 
-INSERT INTO artists VALUES (1);
-INSERT INTO artists VALUES (2);
-INSERT INTO artists VALUES (3);
-INSERT INTO artists VALUES (4);
+INSERT INTO artists (node_id, num_spotify_followers) VALUES (1, 4000);
+INSERT INTO artists (node_id, num_spotify_followers) VALUES (2, 3000);
+INSERT INTO artists (node_id, num_spotify_followers) VALUES (3, 2000);
+INSERT INTO artists (node_id, num_spotify_followers) VALUES (4, 1000);
 
-INSERT INTO nodes VALUES ("Despacito", "song", 10);
-INSERT INTO nodes VALUES ("Rock Your Body", "song", 11);
-INSERT INTO nodes VALUES ("Beautiful Day", "song", 12);
-INSERT INTO nodes VALUES ("In My Blood", "song", 13);
-INSERT INTO nodes VALUES ("Sorry", "song", 14);
+INSERT INTO nodes (name, type, id) VALUES ("Despacito", "song", 10);
+INSERT INTO nodes (name, type, id) VALUES ("Rock Your Body", "song", 11);
+INSERT INTO nodes (name, type, id) VALUES ("Beautiful Day", "song", 12);
+INSERT INTO nodes (name, type, id) VALUES ("In My Blood", "song", 13);
+INSERT INTO nodes (name, type, id) VALUES ("Sorry", "song", 14);
 
-INSERT INTO songs VALUES (1, 10);
-INSERT INTO songs VALUES (1, 14);
-INSERT INTO songs VALUES (2, 11);
-INSERT INTO songs VALUES (3, 12);
-INSERT INTO songs VALUES (4, 13);
+INSERT INTO nodes (name, type, id) VALUES ("Pop", "genre", 20);
+INSERT INTO nodes (name, type, id) VALUES ("Super pop", "genre", 21);
+
+INSERT INTO songs (main_artist_id, popularity, duration_ms, node_id) VALUES (1, 10, 222222, 10);
+INSERT INTO songs (main_artist_id, popularity, duration_ms, node_id) VALUES (1, 20, 333333, 14);
+INSERT INTO songs (main_artist_id, popularity, duration_ms, node_id) VALUES (2, 30, 444444, 11);
+INSERT INTO songs (main_artist_id, popularity, duration_ms, node_id) VALUES (3, 60, 111111, 12);
+INSERT INTO songs (main_artist_id, node_id) VALUES (4, 13);
 
 -- * Define some edges for testing
 -- -------------------------------
 -- Justin Bieber is similar to Justin Timberlake and Shawn Mendes
-INSERT INTO edges VALUES (1, 2, "similar to", 75);
-INSERT INTO edges VALUES (1, 4, "similar to", 100);
+INSERT INTO edges (source, dest, rel, score) VALUES (1, 2, "similar to", 75);
+INSERT INTO edges (source, dest, rel, score) VALUES (1, 4, "similar to", 100);
+INSERT INTO edges (source, dest, rel, score) VALUES (1, 20, "of genre", 100);
+INSERT INTO edges (source, dest, rel, score) VALUES (1, 21, "of genre", 100);
+INSERT INTO edges (source, dest, rel, score) VALUES (2, 20, "of genre", 100);
 
 -- "Despacito" is similar to "Rock Your Body"
-INSERT INTO edges VALUES (10, 11, "similar to", 100);
+INSERT INTO edges (source, dest, rel, score) VALUES (10, 11, "similar to", 100);
 
 -- Justin Bieber and U2 are related in some unimportant way
-INSERT INTO edges VALUES (1, 3, "other relation", 50);
+INSERT INTO edges (source, dest, rel, score) VALUES (1, 3, "other relation", 50);
 -- "Despacito" and "Beautiful Day" are related in some unimportant way
-INSERT INTO edges VALUES (10, 12, "other relation", 50);
+INSERT INTO edges (source, dest, rel, score) VALUES (10, 12, "other relation", 50);

--- a/scripts/test_data.sql
+++ b/scripts/test_data.sql
@@ -18,7 +18,7 @@ INSERT INTO songs VALUES (2, 11);
 INSERT INTO songs VALUES (3, 12);
 INSERT INTO songs VALUES (4, 13);
 
--- * Define some edges+relations for testing
+-- * Define some edges for testing
 -- -------------------------------
 -- Justin Bieber is similar to Justin Timberlake and Shawn Mendes
 INSERT INTO edges VALUES (1, 2, "similar to", 75);
@@ -27,7 +27,6 @@ INSERT INTO edges VALUES (1, 4, "similar to", 100);
 -- "Despacito" is similar to "Rock Your Body"
 INSERT INTO edges VALUES (10, 11, "similar to", 100);
 
-INSERT INTO relations VALUES ("other relation", false);
 -- Justin Bieber and U2 are related in some unimportant way
 INSERT INTO edges VALUES (1, 3, "other relation", 50);
 -- "Despacito" and "Beautiful Day" are related in some unimportant way

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -20,7 +20,7 @@ class TestDbSchema(unittest.TestCase):
         self.assertEqual(res, False,
             "Expected attempt to connect an unknown entity to fail.")
 
-        res = self.kb_api.get_similar_entities("Unknown Entity")
+        res = self.kb_api.get_related_entities("Unknown Entity")
         self.assertEqual(res, [])
 
     def test_rejects_score_out_of_range(self):
@@ -28,7 +28,7 @@ class TestDbSchema(unittest.TestCase):
         self.assertEqual(res, False,
             "Expected attempt to connect entities with score out-of-range to fail.")
 
-        res = self.kb_api.get_similar_entities("Justin Timberlake")
+        res = self.kb_api.get_related_entities("Justin Timberlake")
         self.assertEqual(len(res), 0)
 
     def test_rejects_duplicate_edge(self):
@@ -51,15 +51,15 @@ class TestDbSchema(unittest.TestCase):
 
     def test_entities_not_null_constraints(self):
         res = self.kb_api.add_artist(None)
-        self.assertEqual(res, False,
+        self.assertEqual(res, None,
             "Expected 'None' value for artist to be rejected.")
 
         res = self.kb_api.add_song("Song name", None)
-        self.assertEqual(res, False,
+        self.assertEqual(res, None,
             "Expected 'None' value for artist to be rejected.")
 
         res = self.kb_api.add_song(None, "Artist name")
-        self.assertEqual(res, False,
+        self.assertEqual(res, None,
             "Expected 'None' value for artist to be rejected.")
 
         node_id = self.kb_api._add_node(None, "artist")

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -23,11 +23,6 @@ class TestDbSchema(unittest.TestCase):
         res = self.kb_api.get_similar_entities("Unknown Entity")
         self.assertEqual(res, [])
 
-    def test_rejects_unknown_relation(self):
-        res = self.kb_api.connect_entities("Shawn Mendes", "Justin Timberlake", "unknown relation", 0)
-        self.assertEqual(res, False,
-            "Expected attempt to connect entities with unknown relation to fail.")
-
     def test_rejects_score_out_of_range(self):
         res = self.kb_api.connect_entities("Justin Timberlake", "Justin Timberlake", "similar to", -1)
         self.assertEqual(res, False,

--- a/tests/test_knowledge_base_api.py
+++ b/tests/test_knowledge_base_api.py
@@ -112,7 +112,14 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
     def test_get_matching_node_ids(self):
         node_ids = self.kb_api._get_matching_node_ids("Justin Bieber")
         self.assertEqual(len(node_ids), 1,
-            "Expected to find exactly one node id for 'Justin Bieber', but got: {}"
+            "Expected to find exactly one matching node for 'Justin Bieber', but got: {}"
+                .format(node_ids)
+        )
+
+    def test_get_matching_node_ids_empty(self):
+        node_ids = self.kb_api._get_matching_node_ids("Unknown artist")
+        self.assertEqual(len(node_ids), 0,
+            "Expected to find no matching node for 'Unknown artist', but got: {}"
                 .format(node_ids)
         )
 

--- a/tests/test_knowledge_base_api.py
+++ b/tests/test_knowledge_base_api.py
@@ -27,6 +27,17 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
         res = self.kb_api.get_song_data("Not In Database")
         self.assertEqual(res, [], "Expected empty list of results for queried song not in DB.")
 
+    def test_get_songs(self):
+        res = self.kb_api.get_songs("Justin Bieber")
+        self.assertEqual(res, ["Despacito", "Sorry"], "Songs retrieved for 'Justin Bieber' did not match expected.")
+
+        res = self.kb_api.get_songs("Justin Timberlake")
+        self.assertEqual(res, ["Rock Your Body"], "Songs retrieved for 'Justin Timberlake' did not match expected.")
+
+    def test_get_songs_unknown_artist(self):
+        res = self.kb_api.get_songs("Unknown artist")
+        self.assertEqual(res, None, "Unexpected songs retrieved for unknown artist.")
+
     def test_find_similar_song(self):
         res = self.kb_api.get_similar_entities("Despacito")
         self.assertEqual(

--- a/tests/test_knowledge_base_api.py
+++ b/tests/test_knowledge_base_api.py
@@ -15,17 +15,38 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
         test_db_utils.remove_db()
 
     def test_get_song_data(self):
-        res = self.kb_api.get_song_data("Despacito")
+        song_data = self.kb_api.get_song_data("Despacito")
         # we don't care what the node ID is
-        self.assertEqual(1, len(res), "Expected exactly one result from query for song 'Despacito'.")
-        self.assertIn("song_name", res[0], "Expected to find 'song_name' field in result")
-        self.assertIn("artist_name", res[0], "Expected to find 'artist_name' field in result")
-        self.assertIn(res[0]["song_name"], "Despacito", "Expected to find 'Despacito' for field 'song_name'.")
-        self.assertIn(res[0]["artist_name"], "Justin Bieber", "Expected to find 'Justin Bieber' for field 'artist_name'")
+        self.assertEqual(1, len(song_data), "Expected exactly one result from query for song 'Despacito'.")
+        self.assertEqual(
+            song_data[0],
+            dict(
+                id=10,
+                song_name="Despacito",
+                artist_name="Justin Bieber",
+                duration_ms=222222,
+                popularity=10,
+            ),
+            "Found expected values for song data for 'Despacito'."
+        )
 
     def test_get_song_data_dne(self):
         res = self.kb_api.get_song_data("Not In Database")
         self.assertEqual(res, [], "Expected empty list of results for queried song not in DB.")
+
+    def test_get_artist_data(self):
+        artist_data = self.kb_api.get_artist_data("Justin Bieber")
+        self.assertEqual(len(artist_data), 1, "Expected exactly one result for artist 'Justin Bieber'.")
+        artist_data[0]["genres"] = set(artist_data[0]["genres"])
+        self.assertEqual(
+            artist_data[0],
+            dict(genres=set(["Pop", "Super pop"]), id=1, num_spotify_followers=4000, name="Justin Bieber"),
+            "Artist data for 'Justin Bieber' did not match expected.",
+        )
+
+    def test_get_artist_data_dne(self):
+        artist_data = self.kb_api.get_artist_data("Unknown artist")
+        self.assertEqual(artist_data, [], "Expected 'None' result for unknown artist.")
 
     def test_get_songs(self):
         res = self.kb_api.get_songs("Justin Bieber")
@@ -39,7 +60,7 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
         self.assertEqual(res, None, "Unexpected songs retrieved for unknown artist.")
 
     def test_find_similar_song(self):
-        res = self.kb_api.get_similar_entities("Despacito")
+        res = self.kb_api.get_related_entities("Despacito")
         self.assertEqual(
             len(res), 1,
             "Expected only one song similar to \"Despacito\". Found {0}".format(res),
@@ -50,7 +71,7 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
         )
 
     def test_find_similar_artist(self):
-        res = self.kb_api.get_similar_entities("Justin Bieber")
+        res = self.kb_api.get_related_entities("Justin Bieber")
         self.assertEqual(
             len(res), 2,
             "Expected exactly two artists similar to Justin Bieber.",
@@ -72,23 +93,45 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
         )
 
     def test_find_similar_to_entity_that_dne(self):
-        res = self.kb_api.get_similar_entities("Unknown Entity")
+        res = self.kb_api.get_related_entities("Unknown Entity")
         self.assertEqual(res, [])
 
-    def test_connect_entities(self):
-        res = self.kb_api.get_similar_entities("Shawn Mendes")
+    def test_get_related_genres(self):
+        genre_rel_str = self.kb_api.approved_relations["genre"]
+        rel_genres = self.kb_api.get_related_entities("Justin Bieber", rel_str=genre_rel_str)
+        self.assertEqual(set(rel_genres), set(["Pop", "Super pop"]),
+            "Did not find expected related genres for artist 'Justin Bieber'")
+
+        rel_genres = self.kb_api.get_related_entities("Justin Timberlake", rel_str=genre_rel_str)
+        self.assertEqual(rel_genres, ["Pop"],
+            "Did not find expected related genres for artist 'Justin Timberlake'")
+
+    def test_connect_entities_by_similarity(self):
+        res = self.kb_api.get_related_entities("Shawn Mendes")
         self.assertEqual(len(res), 0)
 
         res = self.kb_api.connect_entities("Shawn Mendes", "Justin Timberlake", "similar to", 0)
         self.assertEqual(res, True, "")
 
-        res = self.kb_api.get_similar_entities("Shawn Mendes")
+        res = self.kb_api.get_related_entities("Shawn Mendes")
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0], "Justin Timberlake")
 
+    def test_connect_entities_by_genre(self):
+        genre_rel_str = self.kb_api.approved_relations["genre"]
+        res = self.kb_api.get_related_entities("Shawn Mendes", rel_str=genre_rel_str)
+        self.assertEqual(len(res), 0)
+
+        res = self.kb_api.connect_entities("Shawn Mendes", "Pop", "of genre", 100)
+        self.assertEqual(res, True, "")
+
+        res = self.kb_api.get_related_entities("Shawn Mendes", rel_str=genre_rel_str)
+        self.assertEqual(len(res), 1, "Expected to find exactly one related genre for 'Shawn Mendes'.")
+        self.assertEqual(res[0], "Pop", "Found unexpected genre for 'Shawn Mendes'.")
+
     def test_rejects_connect_ambiguous_entities(self):
-        res = self.kb_api.add_artist("Artist and Song name clash")
-        res = self.kb_api.add_song("Artist and Song name clash", "U2")
+        self.kb_api.add_artist("Artist and Song name clash")
+        self.kb_api.add_song("Artist and Song name clash", "U2")
 
         res = self.kb_api.connect_entities("Artist and Song name clash", "Justin Timberlake", "similar to", 0)
         self.assertEqual(res, False, "")
@@ -136,53 +179,125 @@ class TestMusicKnowledgeBaseAPI(unittest.TestCase):
         )
 
     def test_add_artist(self):
-        res = self.kb_api.add_artist("Heart")
-        self.assertEqual(res, True, "Failed to add artist 'Heart' to knowledge base.")
+        sample_genres = ["Pop", "Very pop", "Omg so pop"]
+        new_artist_node_id = self.kb_api.add_artist("Heart", genres=sample_genres, num_spotify_followers=1)
+        self.assertNotEqual(new_artist_node_id, None, "Failed to add artist 'Heart' to knowledge base.")
 
-        res = self.kb_api.get_node_ids_by_entity_type("Heart")
-        self.assertTrue("artist" in res,
-            "Expected to find an 'artist' entity with name 'Heart', but got: {0}".format(res))
+        artist_data = self.kb_api.get_artist_data("Heart")
+        self.assertEqual(len(artist_data), 1, "Expected unique match for artist 'Heart'.")
+
+        artist_data = artist_data[0]
+        artist_data["genres"] = set(artist_data["genres"])
+
+        self.assertEqual(
+            artist_data,
+            dict(
+                name="Heart",
+                id=new_artist_node_id,
+                genres=set(sample_genres),
+                num_spotify_followers=1,
+            ),
+            "Did not find expected genres for artist 'Heart'.",
+        )
 
     def test_reject_add_artist_already_exists(self):
+        artist_node_id = self.kb_api.get_artist_data("Justin Bieber")[0]["id"]
         res = self.kb_api.add_artist("Justin Bieber")
-        self.assertEqual(res, False, "Expected rejection of attempt to add artist 'Justin Bieber' to knowledge base.")
+        self.assertEqual(res, artist_node_id, "Expected rejection of attempt to add artist 'Justin Bieber' to knowledge base.")
+
+    def test_add_artist_omitted_opt_params(self):
+        res = self.kb_api.add_artist("Heart")
+        self.assertNotEqual(res, None, "Failed to add artist 'Heart' to knowledge base.")
+
+        artist_data = self.kb_api.get_artist_data("Heart")
+        self.assertEqual(len(artist_data), 1, "Expected unique match for artist 'Heart'.")
+        self.assertEqual(artist_data[0]["name"], "Heart", "Expected match for artist 'Heart'.")
+        self.assertEqual(artist_data[0]["genres"], [], "Expected no genres for artist 'Heart'.")
+        self.assertEqual(artist_data[0]["num_spotify_followers"], None, "Expected no genres for artist 'Heart'.")
 
     def test_add_song(self):
-        res = self.kb_api.add_song("Heart", "Justin Bieber")
-        self.assertEqual(res, True, "Failed to add song 'Heart' by artist 'Justin Bieber' to knowledge base.")
+        new_song_node_id = self.kb_api.add_song("Heart", "Justin Bieber", duration_ms=11111, popularity=100)
+        self.assertNotEqual(new_song_node_id, None, "Failed to add song 'Heart' by artist 'Justin Bieber' to knowledge base.")
 
-        res = self.kb_api.get_node_ids_by_entity_type("Heart")
-        self.assertIn("song", res,
-            "Expected to find 'song' entities with name 'Heart', but got: {0}".format(res))
-        self.assertEqual(len(res["song"]), 1,
-            "Expected to find exactly one 'song' entity with name 'Heart', but got: {0}".format(res))
+        song_data = self.kb_api.get_song_data("Heart")
+        self.assertEqual(len(song_data), 1, "Expected exactly one result.")
+
+        song_data = song_data[0]
+        self.assertEqual(
+            song_data,
+            dict(
+                id=new_song_node_id,
+                song_name="Heart",
+                artist_name="Justin Bieber",
+                duration_ms=11111,
+                popularity=100
+            ),
+            "Received unexpected song data"
+        )
+
+    def test_add_song_omitted_opt_params(self):
+        new_song_node_id = self.kb_api.add_song("What do you mean?", "Justin Bieber")
+        self.assertNotEqual(new_song_node_id, None, "Failed to add song 'sorry' by artist 'Justin Bieber' to knowledge base.")
+
+        song_data = self.kb_api.get_song_data("What do you mean?")
+        self.assertEqual(len(song_data), 1, "Expected exactly one result.")
+
+        song_data = song_data[0]
+        self.assertEqual(
+            song_data,
+            dict(
+                id=new_song_node_id,
+                song_name="What do you mean?",
+                artist_name="Justin Bieber",
+                duration_ms=None,
+                popularity=None
+            ),
+            "Received unexpected song data"
+        )
 
     def test_add_duplicate_song_for_different_artist(self):
-        res = self.kb_api.add_song("Despacito", "Justin Timberlake")
-        self.assertEqual(res, True, "Failed to add song 'Despacito' by artist 'Justin Timberlake' to knowledge base.")
+        new_song_node_id = self.kb_api.add_song("Despacito", "Justin Timberlake")
+        self.assertNotEqual(new_song_node_id, None, "Failed to add song 'Despacito' by artist 'Justin Timberlake' to knowledge base.")
 
-        res = self.kb_api.get_node_ids_by_entity_type("Despacito")
-        self.assertIn("song", res,
-            "Expected to find 'song' entities with name 'Despacito', but got: {0}".format(res))
+        res = self.kb_api.get_song_data("Despacito")
+        self.assertEqual(len(res), 2, "Expected exactly one match for song 'Despacito'.")
 
-        self.assertEqual(len(res["song"]), 2, "Expected to find duplicate 'song' entity with name 'Despacito', but got: {0}".format(res["song"]))
+        artists = set([res[0]["artist_name"], res[1]["artist_name"]])
+        self.assertEqual(artists, set(["Justin Bieber", "Justin Timberlake"]),
+            "Expected to find duplicate artists 'Justin Bieber' and 'Justin Timberlake' for song 'Despacito')")
 
     def test_reject_add_song_already_exists(self):
         res = self.kb_api.add_song("Despacito", "Justin Bieber")
-        self.assertEqual(res, False, "Expected rejection of attempt to add song 'Despacito' by 'Justin Bieber' to knowledge base.")
+        self.assertEqual(res, None, "Expected rejection of attempt to add song 'Despacito' by 'Justin Bieber' to knowledge base.")
 
     # The logic tested here is currently implemented in the KR API
     # However, if it is moved to the schema (e.g. trigger functions),
     # then this test can be moved to the schema test module
     def test_new_song_with_unknown_artist_rejected(self):
         res = self.kb_api.add_song("Song by Unknown Artist", "Unknown artist")
-        self.assertEqual(res, False, "Expected song with unknown artist to be rejected")
+        self.assertEqual(res, None, "Expected song with unknown artist to be rejected")
 
-        res = self.kb_api.get_node_ids_by_entity_type("Song by Unknown Artist")
-        self.assertTrue("song" not in res,
+        res = self.kb_api.get_song_data("Song by Unknown Artist")
+        self.assertEqual(len(res), 0,
             "Insertion of song with unknown artist should not have been added to nodes table")
 
-    def test_contains_entity(self):
+    def test_add_genre(self):
+        node_id = self.kb_api.add_genre("hip hop")
+        self.assertEqual(type(node_id), int,
+            "Genre addition appears to have failed: expected int return value (node id) on valid attempt to add genre.")
+
+        res = self.kb_api.add_genre("hip hop")
+        self.assertEqual(res, node_id, "Expected original node id to be fetched when attempting to add duplicate genre.")
+
+    def test_add_genre_creates_node(self):
+        res = self.kb_api.add_genre("hip hop")
+        self.assertEqual(type(res), int,
+            "Genre addition appears to have failed: expected int return value (node id) on valid attempt to add genre.")
+
+        entities = self.kb_api.get_node_ids_by_entity_type("hip hop")
+        self.assertIn("genre", entities, "Expected to find node associated with genre 'hip hop'.")
+
+    def test_get_node_ids_by_entity_type(self):
         res = self.kb_api.get_node_ids_by_entity_type("Justin Timberlake")
         self.assertTrue("artist" in res,
             "Expected to find an 'artist' entity with name 'Justin Timberlake', but got: {0}".format(res))


### PR DESCRIPTION
New and revised API functions:
* **`KnowledgeBaseAPI.get_song_data`**: accepts song name e.g. `"Despacito"` and gives a list of results:
```
[{
  id: 1,
  song_name: "Despacito",
  artist_name: "Justin Bieber",
  duration_ms: 11111,
  popularity: 100,
}, ...]
```


* **`KnowledgeBaseAPI.get_artist_data`**: accepts artist name e.g. `"Justin Bieber"` and gives a list of results:
```
[{
  genres=['Pop'],
  id=1,
  num_spotify_followers=4000,
  name="Justin Bieber",
}, ...]
```

Also:
* `KnowledgeBaseAPI.get_similar_entities` => **`KnowledgeBaseAPI.get_related_entities`**
  * Now used to retrieve adjacent nodes for given node and *any* relation
  * Previously, this function was just for similarity: now we can get genres too!